### PR TITLE
fix proxy not work when lower case is unset.

### DIFF
--- a/pkg/module/prepare_env.go
+++ b/pkg/module/prepare_env.go
@@ -16,10 +16,6 @@ func prepareEnv(gopath, goProxy string) []string {
 	httpProxy := fmt.Sprintf("HTTP_PROXY=%s", os.Getenv("HTTP_PROXY"))
 	httpsProxy := fmt.Sprintf("HTTPS_PROXY=%s", os.Getenv("HTTPS_PROXY"))
 	noProxy := fmt.Sprintf("NO_PROXY=%s", os.Getenv("NO_PROXY"))
-	// need to also check the lower case version of just these three env variables
-	httpProxyLower := fmt.Sprintf("http_proxy=%s", os.Getenv("http_proxy"))
-	httpsProxyLower := fmt.Sprintf("https_proxy=%s", os.Getenv("https_proxy"))
-	noProxyLower := fmt.Sprintf("no_proxy=%s", os.Getenv("no_proxy"))
 	gopathEnv := fmt.Sprintf("GOPATH=%s", gopath)
 	goProxyEnv := fmt.Sprintf("GOPROXY=%s", goProxy)
 	cacheEnv := fmt.Sprintf("GOCACHE=%s", filepath.Join(gopath, "cache"))
@@ -38,11 +34,19 @@ func prepareEnv(gopath, goProxy string) []string {
 		httpProxy,
 		httpsProxy,
 		noProxy,
-		httpProxyLower,
-		httpsProxyLower,
-		noProxyLower,
 		gitSSH,
 		gitSSHCmd,
+	}
+	
+	// need to also check the lower case version of just these three env variables
+	if httpProxyLower, exist := os.LookupEnv("http_proxy"); exist {
+	    cmdEnv = append(cmdEnv, fmt.Sprintf("http_proxy=%s", httpProxyLower))
+	}
+	if httpsProxyLower, exist := os.LookupEnv("https_proxy"); exist {
+	    cmdEnv = append(cmdEnv, fmt.Sprintf("https_proxy=%s", httpsProxyLower))
+	}
+	if noProxyLower, exist := os.LookupEnv("no_proxy"); exist {
+	    cmdEnv = append(cmdEnv, fmt.Sprintf("no_proxy=%s", noProxyLower))
 	}
 
 	if sshAuthSockVal, hasSSHAuthSock := os.LookupEnv("SSH_AUTH_SOCK"); hasSSHAuthSock {


### PR DESCRIPTION
**What is the problem I am trying to address?**

When `HTTP_PROXY`( `HTTPS_RPOXY` or `NO_PROXY`) environment variable is set but `http_proxy`(`https_proxy` or`no_proxy `) enviromnent variable is unset, The upper case environment variable not work.

**How is the fix applied?**

Set the lower case env variable only when it exist.

**Mention the issue number it fixes or add the details of the changes if it doesn't have a specific issue.**

simplely add non-empty judgement before set the three lower case variable into `cmdEnv`. 
